### PR TITLE
semanticClass & Tag Scopes

### DIFF
--- a/Themes/Made of Code.tmTheme
+++ b/Themes/Made of Code.tmTheme
@@ -324,7 +324,7 @@
 			<key>name</key>
 			<string>✘ Doctype/XML Processing</string>
 			<key>scope</key>
-			<string>meta.sgml.html meta.doctype, meta.sgml.html meta.doctype entity, meta.sgml.html meta.doctype string, meta.xml-processing, meta.xml-processing entity, meta.xml-processing string</string>
+			<string>meta.tag.metadata.doctype, meta.tag.metadata.doctype entity, meta.tag.metadata.doctype string, meta.tag.metadata.processing.xml, meta.tag.metadata.processing.xml entity, meta.tag.metadata.processing.xml string</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/Themes/Made of Code.tmTheme
+++ b/Themes/Made of Code.tmTheme
@@ -4,6 +4,8 @@
 <dict>
 	<key>name</key>
 	<string>Made of Code</string>
+	<key>semanticClass</key>
+	<string>theme.dark.made-of-code</string>
 	<key>settings</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Just a couple quick changes.

- We added `semanticClass` to themes a while back for categorization but never got around to making a pull request here.
- Working on a HTML grammar update that will better categorize the tags and the theme needed a simple update to match the new scopes. (Note: The HTML grammar isn't live yet but should be within 24-48 hours, XML is live but nothing is deployed to TextMate users yet. Will deploy everything at one time to prevent issues.)